### PR TITLE
chore: seo the page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,11 @@ This is the source code for (https://cityschedules.us). This website is designed
 
 1. Is recycle getting picked up this week?
 1. How does the holiday affect my trash pickup?
-1. When is my next leaf pickup? *(Coming Soon)*
+1. When is my next leaf pickup? _(Coming Soon)_
 
 And if providing the code as Open Source software helps anyone learn... then that's an added benefit.
 
 **Currently serving Madison, Wisconsin**
-
 
 ## Development Commands
 
@@ -27,7 +26,6 @@ Open up [http://127.0.0.1:8787](http://127.0.0.1:8787) and you should be ready t
 ### `npm run build && npm start`
 
 Previews the production build.
-
 
 ## Deployment
 

--- a/app/data/wi/madison/remote.ts
+++ b/app/data/wi/madison/remote.ts
@@ -45,6 +45,7 @@ export const MadisonAddressSchema = z.object({
       'RR',
       'Run',
       'Spur',
+      'St',
       'Sq',
       'Ter',
       'Trce',
@@ -69,6 +70,7 @@ const MadisonSchedules = [
   'wedB',
   'thuA',
   'thuB',
+  'ThuC', // Madison has a third Thursday schedule, the casing is NOT a typo
   'friA',
   'friB',
 ] as const
@@ -98,7 +100,6 @@ export const fetchSchedule = async (
   )
 
   const schedule = parseSchedule(response.headers.get('location'))
-
   if (!schedule) {
     throw new Error(
       `Invalid schedule: status=${

--- a/app/data/wi/madison/trash-recycle-schedule.ts
+++ b/app/data/wi/madison/trash-recycle-schedule.ts
@@ -22,7 +22,7 @@ type MadisonCalendarEvent = {
  *
  * K.I.S.S. -- don't parse strings when you don't have to.
  */
-const madisonSchedules = new Map<MadisonSchedule, [Day, 'A' | 'B']>([
+const madisonSchedules = new Map<MadisonSchedule, [Day, 'A' | 'B' | 'C']>([
   ['monA', [1, 'A']],
   ['monB', [1, 'B']],
   ['tueA', [2, 'A']],
@@ -31,6 +31,7 @@ const madisonSchedules = new Map<MadisonSchedule, [Day, 'A' | 'B']>([
   ['wedB', [3, 'B']],
   ['thuA', [4, 'A']],
   ['thuB', [4, 'B']],
+  ['ThuC', [4, 'C']],
   ['friA', [5, 'A']],
   ['friB', [5, 'B']],
 ])
@@ -65,7 +66,12 @@ export const getNextWasteEvent = (
       2 ===
     0
 
-  if ((sched === 'A' && weekIsEven) || (sched === 'B' && !weekIsEven)) {
+  if (
+    // schedules A and C appear to be the same
+    (sched === 'A' && weekIsEven) ||
+    (sched === 'C' && weekIsEven) ||
+    (sched === 'B' && !weekIsEven)
+  ) {
     return { date: nextPickupDayExcludingToday, recycle: true, trash: true }
   } else {
     return { date: nextPickupDayExcludingToday, trash: true }

--- a/app/routes/_index/trash-pickup-card.tsx
+++ b/app/routes/_index/trash-pickup-card.tsx
@@ -139,10 +139,21 @@ function RelativeDate({
 
 export interface LoadingTrashPickupCardProps {
   address: Address
+  error?: string
 }
 
-export function ErrorTrashPickupCard({ address }: LoadingTrashPickupCardProps) {
+export function ErrorTrashPickupCard({
+  address,
+  error,
+}: LoadingTrashPickupCardProps) {
   const fetcher = useFetcher({ key: fetcherDeleteKey(address.id) })
+
+  if (error) {
+    console.error('error fetching schedule', {
+      address,
+      reason: error,
+    })
+  }
 
   return (
     <Card padding="lg" radius="md" w="320px">

--- a/app/routes/_index/welcome-modal.tsx
+++ b/app/routes/_index/welcome-modal.tsx
@@ -1,0 +1,32 @@
+import { Group, Modal, Stack, Text } from '@mantine/core'
+import { useMediaQuery } from '@mantine/hooks'
+import { AddFirstAddressButton } from '../../shared'
+
+/**
+ * Opens a modal to add your first address.
+ */
+export function WelcomeModal({ opened }: { opened: boolean }) {
+  const isMobile = useMediaQuery('(max-width: 50em)')
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={() => undefined}
+      withCloseButton={false}
+      fullScreen={isMobile}
+      size="xl"
+      title="Welcome!"
+      transitionProps={{ transition: 'fade', duration: 200 }}
+    >
+      <Stack>
+        <Text>
+          Tired of missing trash and recycling pickup? Add your address to see
+          your local waste collection schedule. We'll remember it for next time.
+        </Text>
+        <Group justify="center">
+          <AddFirstAddressButton />
+        </Group>
+      </Stack>
+    </Modal>
+  )
+}

--- a/app/routes/wi.madison/enter-your-address-form.tsx
+++ b/app/routes/wi.madison/enter-your-address-form.tsx
@@ -83,14 +83,14 @@ export function EnterYourAddressForm({
           <Alert
             variant="light"
             radius="xs"
-            title="Sorry for the dust!"
-            withCloseButton
+            title="Need help?"
             icon={<IconInfoCircle />}
           >
-            I don't (yet) have a sophisticated way to parse a full street
-            address written in a more natural form (e.g. "1234 E Main St Apt
-            2"). So, for now, please enter your address in the format above.
-            Thanks!
+            Visit the{' '}
+            <a href="https://www.cityofmadison.com/streets/refuse/collectionlookup.cfm">
+              Madison Streets division
+            </a>{' '}
+            collection lookup.
           </Alert>
 
           <Button type="submit" fullWidth>

--- a/app/routes/wi.madison/route.tsx
+++ b/app/routes/wi.madison/route.tsx
@@ -10,23 +10,29 @@ import { zfd } from 'zod-form-data'
 import { EnterYourAddressForm } from './enter-your-address-form'
 import { AddressStore } from '../../address-store.server'
 import { StreetDirection, StreetType } from '../../enums'
+import { Breadcrumbs } from '../../shared'
 
 export const meta: MetaFunction = () => {
   return [
-    { title: 'Add an address for Madison, WI' },
+    {
+      title: 'Madison, Wisconsin: Add an Address',
+    },
     {
       name: 'description',
       content:
-        'Add an address for Madison, WI to see your trash and recycling pickup schedule.',
+        "Add an address for Madison, Wisconsin to see your trash and recycling pickup schedule. We'll remember it for next time.",
     },
   ]
 }
+
+const crumbs = [{ title: 'Home', href: '/' }, { title: 'Madison, Wisconsin' }]
 
 export default function Index() {
   const data = useActionData<typeof action>()
 
   return (
     <Container miw={320} maw={1024} w="50%">
+      <Breadcrumbs pb={20}>{crumbs}</Breadcrumbs>
       <Paper shadow="lg" radius="lg" withBorder p="sm">
         <EnterYourAddressForm
           formProps={{

--- a/app/shared/breadcrumbs.tsx
+++ b/app/shared/breadcrumbs.tsx
@@ -1,0 +1,29 @@
+import {
+  Anchor,
+  Breadcrumbs as MantineBreadcrumbs,
+  type BreadcrumbsProps as MantineBreadcrumbsProps,
+} from '@mantine/core'
+
+export interface BreadcrumbsProps
+  extends Omit<MantineBreadcrumbsProps, 'children'> {
+  children: {
+    title: string
+    href?: string
+  }[]
+}
+
+export const Breadcrumbs = ({ children, ...props }: BreadcrumbsProps) => {
+  return (
+    <MantineBreadcrumbs {...props}>
+      {children.map((item) =>
+        item.href ? (
+          <Anchor href={item.href} key={item.title}>
+            {item.title}
+          </Anchor>
+        ) : (
+          <span key={item.title}>{item.title}</span>
+        ),
+      )}
+    </MantineBreadcrumbs>
+  )
+}

--- a/app/shared/buttons.tsx
+++ b/app/shared/buttons.tsx
@@ -1,0 +1,55 @@
+import { ActionIcon, Affix, Box, Button, Group } from '@mantine/core'
+import { IconArrowRight, IconTextPlus } from '@tabler/icons-react'
+
+export interface ResponsiveAddAddressButtonProps {
+  /**
+   * When set the button will be a floating action button.
+   */
+  fab?: boolean
+}
+
+export function ResponsiveAddAddressButton({
+  fab,
+}: ResponsiveAddAddressButtonProps) {
+  if (fab) {
+    return (
+      <Affix hiddenFrom="sm" position={{ bottom: 40, right: 40 }}>
+        <ActionIcon
+          radius="lg"
+          size={60}
+          aria-label="Add an address"
+          component="a"
+          href="/wi/madison"
+        >
+          <IconTextPlus size="24" />
+        </ActionIcon>
+      </Affix>
+    )
+  }
+
+  return (
+    <ActionIcon
+      visibleFrom="sm"
+      radius="lg"
+      size={60}
+      aria-label="Add an address"
+      component="a"
+      href="/wi/madison"
+    >
+      <IconTextPlus size="24" />
+    </ActionIcon>
+  )
+}
+
+export function AddFirstAddressButton() {
+  return (
+    <Button
+      component="a"
+      href="/wi/madison"
+      leftSection={<IconTextPlus size="24" />}
+      rightSection={<IconArrowRight size={14} />}
+    >
+      Add your first address!
+    </Button>
+  )
+}

--- a/app/shared/index.ts
+++ b/app/shared/index.ts
@@ -1,0 +1,9 @@
+export { NavBar } from './navbar'
+
+export {
+  AddFirstAddressButton,
+  ResponsiveAddAddressButton,
+  type ResponsiveAddAddressButtonProps,
+} from './buttons'
+
+export { Breadcrumbs, type BreadcrumbsProps } from './breadcrumbs'

--- a/app/shared/navbar.tsx
+++ b/app/shared/navbar.tsx
@@ -1,0 +1,34 @@
+import { AppShell, Divider, List, Text } from '@mantine/core'
+import { ResponsiveAddAddressButton } from './buttons'
+
+/**
+ * @returns a List of cities by state
+ */
+export function ListOfCitiesByState() {
+  return (
+    <List spacing="md" listStyleType="none">
+      <List.Item>
+        Wisconsin
+        <List withPadding spacing="none" listStyleType="none">
+          <List.Item>
+            <a href="/wi/madison">Madison</a>
+          </List.Item>
+        </List>
+      </List.Item>
+    </List>
+  )
+}
+
+/**
+ * @returns the AppShell.NavBar component
+ */
+export function NavBar() {
+  return (
+    <AppShell.Navbar px="sm">
+      <ResponsiveAddAddressButton />
+      <Text>Locations</Text>
+      <Divider />
+      <ListOfCitiesByState />
+    </AppShell.Navbar>
+  )
+}

--- a/app/styles/root.css
+++ b/app/styles/root.css
@@ -1,11 +1,3 @@
 body {
-  background-image: url(public/images/madison-aerial.avif);
-  background-position: center 25%;
-  background-repeat: no-repeat;
   font-family: system-ui, sans-serif;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 100vh;
-  width: 100vw;
 }


### PR DESCRIPTION
- Stop redirecting to /wi/madison on first load. This confuses
search engines. Instead, we render the index page and have
adding the address be an explicit click.
- Add some better titles, headers, and text to the index page.
- Link to the madison refuse site on our add address form.
- Use an AppShell so we can have a header, navbar, and main body.
- Get rid of the large, expensive images.

ALSO...
- while testing this, I found some bugs in schedule resolution including
a secret ThuC schedule.

TODO: Need to style this up and make this look pretty. But it's
just ship it for now.